### PR TITLE
Add sortColumnsBy DataFraneExt

### DIFF
--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
@@ -411,24 +411,43 @@ object DataFrameExt {
       )
     }
 
-    /** Sorts this DataFrame columns order according to the Ordering which results from transforming
-   *  an implicitly given Ordering with a transformation function.
-   *  @see [[scala.math.Ordering]]
-   *  @param   f the transformation function mapping elements of type [[StructField]]
-   *           to some other domain `A`.
-   *  @param   ord the ordering assumed on domain `A`.
-   *  @tparam  A the target type of the transformation `f`, and the type where
-   *           the ordering `ord` is defined.
-   *  @return  a DataFrame consisting of the fields of this DataFrame
-   *           sorted according to the ordering where `x < y` if
-   *           `ord.lt(f(x), f(y))`.
-   *
-   *  @example {{{
-   *    // this works because scala.Ordering will implicitly provide an Ordering[String]
-   *    df.sortColumnsBy(_.name)
-   *  }}}
-   */
-    def sortColumnsBy[A](f: StructField => A)(implicit ord: Ordering[A]): DataFrame = df
-      .select(df.schema.toSortedSelectExpr(f): _*)
+    /**
+     * Sorts this DataFrame columns order according to the Ordering which results from transforming
+     * an implicitly given Ordering with a transformation function.
+     * This function will also sort [[StructType]] columns and [[ArrayType]]([[StructType]]) columns.
+     *  @see [[scala.math.Ordering]]
+     *  @param   f the transformation function mapping elements of type [[StructField]]
+     *           to some other domain `A`.
+     *  @param   ord the ordering assumed on domain `A`.
+     *  @tparam  A the target type of the transformation `f`, and the type where
+     *           the ordering `ord` is defined.
+     *  @return  a DataFrame consisting of the fields of this DataFrame
+     *           sorted according to the ordering where `x < y` if
+     *           `ord.lt(f(x), f(y))`.
+     *
+     * @example {{{
+     *   // Example DataFrame
+     *   val df = spark.createDataFrame(
+     *     Seq(
+     *       ("John", 30, 2000.0),
+     *       ("Jane", 25, 3000.0)
+     *     )
+     *   ).toDF("name", "age", "salary")
+     *
+     *   // Sort columns by name
+     *   val sortedByNameDF = df.sortColumnsBy(_.name)
+     *   sortedByNameDF.show()
+     *   // Output:
+     *   // +---+----+------+
+     *   // |age|name|salary|
+     *   // +---+----+------+
+     *   // | 30|John|2000.0|
+     *   // | 25|Jane|3000.0|
+     *   // +---+----+------+
+     * }}}
+     */
+    def sortColumnsBy[A](f: StructField => A)(implicit ord: Ordering[A]): DataFrame =
+      df
+        .select(df.schema.toSortedSelectExpr(f): _*)
   }
 }

--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
@@ -6,6 +6,8 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{ArrayType, DataType, StructField, StructType}
 import org.apache.spark.sql.{Column, DataFrame}
 
+import scala.collection.mutable
+
 case class DataFrameColumnsException(smth: String) extends Exception(smth)
 
 object DataFrameExt {
@@ -266,9 +268,9 @@ object DataFrameExt {
      * This StackOverflow answer provides a detailed description how to use flattenSchema: https://stackoverflow.com/a/50402697/1125159
      */
     def flattenSchema(delimiter: String = "."): DataFrame = {
-      val renamedCols: Array[Column] = StructTypeHelpers
+      val renamedCols = StructTypeHelpers
         .flattenSchema(df.schema)
-        .map(name => col(name.toString).as(name.toString.replace(".", delimiter)))
+        .map(c => c.as(c.toString.replace(".", delimiter)))
       df.select(renamedCols: _*)
     }
 
@@ -407,6 +409,8 @@ object DataFrameExt {
         StructType(loop(df.schema))
       )
     }
-  }
 
+    def selectSortedCols: DataFrame = df
+      .select(StructTypeHelpers.schemaToSortedSelectExpr(df.schema): _*)
+  }
 }

--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
@@ -1,6 +1,7 @@
 package com.github.mrpowers.spark.daria.sql
 
 import com.github.mrpowers.spark.daria.sql.types.StructTypeHelpers
+import com.github.mrpowers.spark.daria.sql.types.StructTypeHelpers.StructTypeOps
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{ArrayType, DataType, StructField, StructType}
@@ -410,7 +411,24 @@ object DataFrameExt {
       )
     }
 
-    def selectSortedCols: DataFrame = df
-      .select(StructTypeHelpers.schemaToSortedSelectExpr(df.schema): _*)
+    /** Sorts this DataFrame columns order according to the Ordering which results from transforming
+   *  an implicitly given Ordering with a transformation function.
+   *  @see [[scala.math.Ordering]]
+   *  @param   f the transformation function mapping elements of type [[StructField]]
+   *           to some other domain `A`.
+   *  @param   ord the ordering assumed on domain `A`.
+   *  @tparam  A the target type of the transformation `f`, and the type where
+   *           the ordering `ord` is defined.
+   *  @return  a DataFrame consisting of the fields of this DataFrame
+   *           sorted according to the ordering where `x < y` if
+   *           `ord.lt(f(x), f(y))`.
+   *
+   *  @example {{{
+   *    // this works because scala.Ordering will implicitly provide an Ordering[String]
+   *    df.sortColumnsBy(_.name)
+   *  }}}
+   */
+    def sortColumnsBy[A](f: StructField => A)(implicit ord: Ordering[A]): DataFrame = df
+      .select(df.schema.toSortedSelectExpr(f): _*)
   }
 }

--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
@@ -447,7 +447,6 @@ object DataFrameExt {
      * }}}
      */
     def sortColumnsBy[A](f: StructField => A)(implicit ord: Ordering[A]): DataFrame =
-      df
-        .select(df.schema.toSortedSelectExpr(f): _*)
+      df.select(df.schema.toSortedSelectExpr(f): _*)
   }
 }

--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/DataFrameExt.scala
@@ -269,9 +269,9 @@ object DataFrameExt {
      * This StackOverflow answer provides a detailed description how to use flattenSchema: https://stackoverflow.com/a/50402697/1125159
      */
     def flattenSchema(delimiter: String = "."): DataFrame = {
-      val renamedCols = StructTypeHelpers
+      val renamedCols: Array[Column] = StructTypeHelpers
         .flattenSchema(df.schema)
-        .map(c => c.as(c.toString.replace(".", delimiter)))
+        .map(name => col(name.toString).as(name.toString.replace(".", delimiter)))
       df.select(renamedCols: _*)
     }
 

--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
@@ -21,13 +21,14 @@ object StructTypeHelpers {
     }
   }
 
-  def flattenSchema(schema: StructType, baseField: String = "", sortFields: Boolean = false): Seq[Column] = {
-    val fields  = if (sortFields) schema.fields.sortBy(_.name) else schema.fields
-    fields.foldLeft(Seq.empty[Column]) { case(acc, field) =>
+  def flattenSchema(schema: StructType, baseField: String = "", flattenArrayType: Boolean = false): Seq[Column] = {
+    schema.fields.foldLeft(Seq.empty[Column]) { case(acc, field) =>
       val colName = if (baseField.isEmpty) field.name else s"$baseField.${field.name}"
       field.dataType match {
         case t: StructType =>
-          acc ++ flattenSchema(t, baseField = colName, sortFields = sortFields)
+          acc ++ flattenSchema(t, colName)
+        case ArrayType(t: StructType, _) if flattenArrayType =>
+          acc ++ flattenSchema(t, colName)
         case _ =>
           acc :+ col(colName)
       }

--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
@@ -67,13 +67,6 @@ object StructTypeHelpers {
     }
   }
 
-  @tailrec
-  private def getInnerMostType(dType: DataType, nDim: Int = 0): (DataType, Int) =
-    dType match {
-      case at: ArrayType => getInnerMostType(at.elementType, nDim + 1)
-      case t             => (t, nDim)
-    }
-
   /**
    * gets a StructType from a Scala type and
    * transforms field names from camel case to snake case

--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
@@ -63,10 +63,7 @@ object StructTypeHelpers {
         case _ if !firstLevel => parentCol(childFieldName)
       }
 
-    schema.fields.sortBy(f).foldLeft(Seq.empty[Column]) {
-      case (acc, field) =>
-        acc :+ childFieldToCol(field.dataType, field.name, col(field.name), firstLevel = true)
-    }
+    schema.fields.sortBy(f).map(field => childFieldToCol(field.dataType, field.name, col(field.name), firstLevel = true))
   }
 
   /**

--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
@@ -56,7 +56,7 @@ object StructTypeHelpers {
         case ArrayType(innerType: ArrayType, _) => transform(innerCol, outer => handleArrayType(innerType, outer, simpleName))
         case ArrayType(innerType: StructType, _) =>
           val cols = schemaToSortedSelectExpr(innerType, f)
-          transform(innerCol, innerCol1 => struct(cols.map(c => innerCol1.getField(c.toString).as(c.toString)): _*)).as(simpleName)
+          transform(innerCol, innerCol1 => struct(cols.map(c => innerCol1.getField(c.toString).as(c.toString)): _*))
         case _ => innerCol
       }
 

--- a/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/daria/sql/types/StructTypeHelpers.scala
@@ -57,7 +57,7 @@ object StructTypeHelpers {
                 ).as(field.name)
               ): _*
           ).as(childFieldName)
-        case ArrayType(innerType, _)  =>
+        case ArrayType(innerType, _) =>
           transform(parentCol, childCol => childFieldToCol(innerType, childFieldName, childCol)).as(childFieldName)
         case _ if firstLevel  => parentCol
         case _ if !firstLevel => parentCol(childFieldName)

--- a/core/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
@@ -961,6 +961,199 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
 
     }
 
+    'selectSortedCols - {
+
+      "select col with all field sorted" - {
+
+        val data = Seq(
+          Row(
+            Row(
+              "bayVal",
+              "baxVal",
+              Row("this", "yoVal"),
+              "is"
+            ),
+            Seq(
+              Row("yVal", "xVal"),
+              Row("yVal1", "xVal1")
+            ),
+            "something",
+            "cool",
+            ";)"
+          )
+        )
+
+        val schema = StructType(
+          Seq(
+            StructField(
+              "foo",
+              StructType(
+                Seq(
+                  StructField(
+                    "bay",
+                    StringType,
+                    true
+                  ),
+                  StructField(
+                    "bax",
+                    StringType,
+                    true
+                  ),
+                  StructField(
+                    "bar",
+                    StructType(
+                      Seq(
+                        StructField(
+                          "zoo",
+                          StringType,
+                          true
+                        ),
+                        StructField(
+                          "yoo",
+                          StringType,
+                          true
+                        )
+                      )
+                    )
+                  ),
+                  StructField(
+                    "baz",
+                    StringType,
+                    true
+                  ),
+                )
+              ),
+              true
+            ),
+            StructField(
+              "w",
+              ArrayType(StructType(Seq(StructField("y", StringType, true), StructField("x", StringType, true)))),
+              true
+            ),
+            StructField(
+              "x",
+              StringType,
+              true
+            ),
+            StructField(
+              "y",
+              StringType,
+              true
+            ),
+            StructField(
+              "z",
+              StringType,
+              true
+            )
+          )
+        )
+
+        val df = spark
+          .createDataFrame(
+            spark.sparkContext.parallelize(data),
+            StructType(schema)
+          )
+          .selectSortedCols
+
+        val expectedData = Seq(
+          Row(
+            Row(
+              Row("yoVal", "this"),
+              "baxVal",
+              "bayVal",
+              "is"
+            ),
+            Seq(
+              Row("xVal", "yVal"),
+              Row("xVal1", "yVal1")
+            ),
+            "something",
+            "cool",
+            ";)"
+          )
+        )
+
+        val expectedSchema = StructType(
+          Seq(
+            StructField(
+              "foo",
+              StructType(
+                Seq(
+                  StructField(
+                    "bar",
+                    StructType(
+                      Seq(
+                        StructField(
+                          "yoo",
+                          StringType,
+                          true
+                        ),
+                        StructField(
+                          "zoo",
+                          StringType,
+                          true
+                        )
+                      )
+                    ),
+                    false
+                  ),
+                  StructField(
+                    "bax",
+                    StringType,
+                    true
+                  ),
+                  StructField(
+                    "bay",
+                    StringType,
+                    true
+                  ),
+                  StructField(
+                    "baz",
+                    StringType,
+                    true
+                  )
+                )
+              ),
+              false
+            ),
+            StructField(
+              "w",
+              ArrayType(StructType(Seq(StructField("x", StringType, true), StructField("y", StringType, true))), false),
+              true
+            ),
+            StructField(
+              "x",
+              StringType,
+              true
+            ),
+            StructField(
+              "y",
+              StringType,
+              true
+            ),
+            StructField(
+              "z",
+              StringType,
+              true
+            )
+          )
+        )
+
+        val expectedDF = spark
+          .createDataFrame(
+            spark.sparkContext.parallelize(expectedData),
+            StructType(expectedSchema)
+          )
+
+        assertSmallDataFrameEquality(
+          df,
+          expectedDF,
+          ignoreNullable = true
+        )
+      }
+
+    }
+
     'structureSchema - {
       "structure schema with default delimiter" - {
         val data = Seq(
@@ -1125,6 +1318,7 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
 
       }
     }
+
     'composeTrans - {
 
       def withCountry()(df: DataFrame): DataFrame = {

--- a/core/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
@@ -1053,7 +1053,7 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
             spark.sparkContext.parallelize(data),
             StructType(schema)
           )
-          .selectSortedCols
+          .sortColumnsBy(_.name)
 
         val expectedData = Seq(
           Row(

--- a/core/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
@@ -1185,14 +1185,14 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
             Seq(
               Row("yVal", "xVal"),
               Row("yVal1", "xVal1")
+            ),
+            Seq(
+              Row(
+                Seq(
+                  Row("x4Val", "x3Val")
+                )
+              )
             )
-//            Seq(
-//              Row(
-//                Seq(
-//                  Row("x4Val", "x3Val")
-//                )
-//              )
-//            )
           )
         )
 
@@ -1220,12 +1220,16 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
               "w",
               ArrayType(StructType(Seq(StructField("y", StringType, true), StructField("x", StringType, true)))),
               true
+            ),
+            StructField(
+              "x",
+              ArrayType(
+                StructType(
+                  Seq(StructField("x1", ArrayType(StructType(Seq(StructField("b", StringType, true), StructField("a", StringType, true)))), true))
+                )
+              ),
+              true
             )
-//            StructField(
-//              "x",
-//              ArrayType(StructType(Seq(StructField("x1", ArrayType(StructType(Seq(StructField("x4", StringType, true), StructField("x3", StringType, true)))), true)))),
-//              true
-//            ),
           )
         )
 
@@ -1252,14 +1256,14 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
             Seq(
               Row("xVal", "yVal"),
               Row("xVal1", "yVal1")
+            ),
+            Seq(
+              Row(
+                Seq(
+                  Row("x3Val", "x4Val")
+                )
+              )
             )
-//            Seq(
-//              Row(
-//                Seq(
-//                  Row("x3Val", "x4Val")
-//                )
-//              )
-//            )
           )
         )
 
@@ -1287,12 +1291,19 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
               "w",
               ArrayType(StructType(Seq(StructField("x", StringType, true), StructField("y", StringType, true))), false),
               true
+            ),
+            StructField(
+              "x",
+              ArrayType(
+                StructType(
+                  Seq(
+                    StructField("x1", ArrayType(StructType(Seq(StructField("a", StringType, true), StructField("b", StringType, true))), false), true)
+                  )
+                ),
+                false
+              ),
+              true
             )
-//            StructField(
-//              "x",
-//              ArrayType(StructType(Seq(StructField("x1", ArrayType(StructType(Seq(StructField("x3", StringType, true), StructField("x4", StringType, true)))), true)))),
-//              true
-//            )
           )
         )
 

--- a/core/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/daria/sql/DataFrameExtTest.scala
@@ -963,7 +963,7 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
 
     'selectSortedCols - {
 
-      "select col with all field sorted" - {
+      "select col with all field sorted by name" - {
 
         val data = Seq(
           Row(
@@ -972,6 +972,11 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
               "baxVal",
               Row("this", "yoVal"),
               "is"
+            ),
+            Seq(
+              Seq(
+                Row("yVal", "xVal"),
+                Row("yVal1", "xVal1")),
             ),
             Seq(
               Row("yVal", "xVal"),
@@ -1026,6 +1031,11 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
               true
             ),
             StructField(
+              "v",
+              ArrayType(ArrayType(StructType(Seq(StructField("v2", StringType, true), StructField("v1", StringType, true))))),
+              true
+            ),
+            StructField(
               "w",
               ArrayType(StructType(Seq(StructField("y", StringType, true), StructField("x", StringType, true)))),
               true
@@ -1062,6 +1072,12 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
               "baxVal",
               "bayVal",
               "is"
+            ),
+            Seq(
+              Seq(
+                Row("xVal", "yVal"),
+                Row("xVal1", "yVal1")
+              )
             ),
             Seq(
               Row("xVal", "yVal"),
@@ -1117,6 +1133,11 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
               false
             ),
             StructField(
+              "v",
+              ArrayType(ArrayType(StructType(Seq(StructField("v1", StringType, true), StructField("v2", StringType, true))), false)),
+              true
+            ),
+            StructField(
               "w",
               ArrayType(StructType(Seq(StructField("x", StringType, true), StructField("y", StringType, true))), false),
               true
@@ -1147,6 +1168,37 @@ object DataFrameExtTest extends TestSuite with DataFrameComparer with SparkSessi
 
         assertSmallDataFrameEquality(
           df,
+          expectedDF,
+          ignoreNullable = true
+        )
+      }
+
+      "select col with all field sorted by custom dataType ordering" - {
+
+        val actualDF =
+          spark.createDF(
+            List(("this", 1, 1L, 1.0)),
+            List(
+              ("a", StringType, true),
+              ("b", IntegerType, true),
+              ("c", LongType, true),
+              ("d", DoubleType, true),
+            )
+          ).sortColumnsBy(_.dataType)(Ordering.by(_.json))
+
+        val expectedDF =
+          spark.createDF(
+            List((1.0, 1, 1L, "this")),
+            List(
+              ("d", DoubleType, true),
+              ("b", IntegerType, true),
+              ("c", LongType, true),
+              ("a", StringType, true),
+            )
+          )
+
+        assertSmallDataFrameEquality(
+          actualDF,
           expectedDF,
           ignoreNullable = true
         )


### PR DESCRIPTION
This was inspired by https://stackoverflow.com/questions/57821538/how-to-sort-columns-of-nested-structs-alphabetically-in-pyspark#:~:text=You%20can%20first%20flatten%20your%20DF%20with%20the%20nice%20colname.*

Here we support more flexible sorting by allowing user to provide a custom transformation and implicit ordering. 

+ add support to sorting of ArrayType(StructType) column which was not available in original implementation